### PR TITLE
Fix: Resolve build errors in event_camera_tools

### DIFF
--- a/include/event_camera_tools/check_endian.h
+++ b/include/event_camera_tools/check_endian.h
@@ -23,7 +23,7 @@ namespace event_camera_tools
 namespace check_endian
 {
 // check endianness
-inline constexpr bool isBigEndian()
+inline bool isBigEndian()
 {
   const union {
     uint32_t i;

--- a/src/bag_to_raw_ros2.cpp
+++ b/src/bag_to_raw_ros2.cpp
@@ -80,7 +80,6 @@ static size_t process_bag(
   out.open(outFile, std::ios::out | std::ios::binary);
   out.write(header.c_str(), header.size());
   size_t numBytes(0);
-  size_t numMessages(0);
   {
     rosbag2_cpp::Reader reader;
     reader.open(inFile);
@@ -94,7 +93,6 @@ static size_t process_bag(
         serialization.deserialize_message(&serializedMsg, &m);
         numBytes +=
           write(out, &m.events[0], m.events.size(), m.time_base, m.encoding, &last_evt_stamp);
-        numMessages++;
       }
     }
   }  // close reader when out of scope

--- a/src/perf_ros2.cpp
+++ b/src/perf_ros2.cpp
@@ -15,6 +15,7 @@
 
 #include <event_camera_codecs/decoder_factory.h>
 #include <event_camera_codecs/event_processor.h>
+#include <inttypes.h>
 #include <unistd.h>
 
 #include <chrono>
@@ -22,7 +23,6 @@
 #include <fstream>
 #include <rclcpp/rclcpp.hpp>
 #include <unordered_map>
-#include <inttypes.h>
 
 void usage()
 {

--- a/src/perf_ros2.cpp
+++ b/src/perf_ros2.cpp
@@ -100,7 +100,7 @@ public:
     const double dt = (t - lastTime_).nanoseconds() * 1e-9;  // in milliseconds
     if (numMsgs_ != 0 && t_elapsed > 1e-3) {
       printf(
-        "%.0f msgs: %8.2f/s drp: %2zu del: %5.2fms drft: %8.4fs", t_elapsed, numMsgs_ / dt,
+        "%.0f msgs: %8.2f/s drp: %2llu del: %5.2fms drft: %8.4fs", t_elapsed, numMsgs_ / dt,
         numSeqDropped_, delay_ / (1e6 * numMsgs_), drift_ * 1e-9);
       const size_t cdTot = cdEvents_[0] + cdEvents_[1];
       if (cdTot > 0) {

--- a/src/perf_ros2.cpp
+++ b/src/perf_ros2.cpp
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <rclcpp/rclcpp.hpp>
 #include <unordered_map>
+#include <inttypes.h>
 
 void usage()
 {
@@ -100,7 +101,7 @@ public:
     const double dt = (t - lastTime_).nanoseconds() * 1e-9;  // in milliseconds
     if (numMsgs_ != 0 && t_elapsed > 1e-3) {
       printf(
-        "%.0f msgs: %8.2f/s drp: %2llu del: %5.2fms drft: %8.4fs", t_elapsed, numMsgs_ / dt,
+        "%.0f msgs: %8.2f/s drp: %" PRIu64 "del: %5.2fms drft: %8.4fs", t_elapsed, numMsgs_ / dt,
         numSeqDropped_, delay_ / (1e6 * numMsgs_), drift_ * 1e-9);
       const size_t cdTot = cdEvents_[0] + cdEvents_[1];
       if (cdTot > 0) {

--- a/src/sync_test_ros2.cpp
+++ b/src/sync_test_ros2.cpp
@@ -21,6 +21,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <unordered_map>
+#include <inttypes.h>
 
 void usage()
 {
@@ -91,7 +92,7 @@ private:
       const auto count = count_[0] + count_[1];
       const double avg = sumOfDiffs_ / count;
       const double shift[2] = {baseVsStampShift_[0] / count, baseVsStampShift_[1] / count};
-      printf("avg sensor diff: %8.5lfs, count: %5llu, ", avg, count);
+      printf("avg sensor diff: %8.5lfs, count: %" PRIu64 "\n", avg, count);
       printf("base-stamp shift:  [0]: %8.5lfs, [1]: %8.5lfs\n", shift[0], shift[1]);
     } else {
       RCLCPP_WARN_STREAM(

--- a/src/sync_test_ros2.cpp
+++ b/src/sync_test_ros2.cpp
@@ -91,7 +91,7 @@ private:
       const auto count = count_[0] + count_[1];
       const double avg = sumOfDiffs_ / count;
       const double shift[2] = {baseVsStampShift_[0] / count, baseVsStampShift_[1] / count};
-      printf("avg sensor diff: %8.5lfs, count: %5zu, ", avg, count);
+      printf("avg sensor diff: %8.5lfs, count: %5llu, ", avg, count);
       printf("base-stamp shift:  [0]: %8.5lfs, [1]: %8.5lfs\n", shift[0], shift[1]);
     } else {
       RCLCPP_WARN_STREAM(

--- a/src/sync_test_ros2.cpp
+++ b/src/sync_test_ros2.cpp
@@ -15,13 +15,13 @@
 
 #include <event_camera_codecs/decoder_factory.h>
 #include <event_camera_codecs/event_processor.h>
+#include <inttypes.h>
 
 #include <event_camera_msgs/msg/event_packet.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <unordered_map>
-#include <inttypes.h>
 
 void usage()
 {


### PR DESCRIPTION
This pull request addresses several compiler errors to enable a successful build of the `event_camera_tools` package on strict compilers like `AppleClang.` The changes resolve the following issues:

Compiler Warning Fixes: Removed an unused variable `(numMessages)` and corrected multiple printf format strings to ensure their specifiers (e.g., `%llu`) match the corresponding variable types.

Invalid constexpr Fix: Removed the constexpr keyword from the `isBigEndian()` function. The function's logic was not compatible with the strict requirements for compile-time evaluation in modern C++, which caused a fatal build error.