### PR TITLE
added jitter measurement to perf tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ and follow the [instructions here](https://github.com/ros-misc-utilities/.github
   Sample output:
 
   ```text
-  msgs:   219.48/s drp:  0 del: 13.72ms drft: 0.0033s ev:   0.0823 M/s %ON:  46 tr:  1758.38 1/s %UP:  50
-  msgs:   249.01/s drp:  0 del:  4.35ms drft: 0.0027s ev:   0.8497 M/s %ON:  52 tr:  1999.56 1/s %UP:  49
+  msgs:   219.48/s drp:  0 del: 13.72ms drft:  0.0297ms jit:  0.3296ms ev:   0.0823 M/s %ON:  46 tr:  1758.38 1/s %UP:  50
+  msgs:   249.01/s drp:  0 del:  4.35ms drft: -0.0031ms jit:  0.2503ms ev:   0.8497 M/s %ON:  52 tr:  1999.56 1/s %UP:  49
    ```
 
   The meaning of the fields is as follows:
@@ -64,6 +64,7 @@ and follow the [instructions here](https://github.com/ros-misc-utilities/.github
      aggregating messages.
   - ``drft`` accumulated (from start of "perf") drift between message
      header stamp and sensor-provided time.
+  - ``jit`` measured jitter of ROS time stamps vs sensor time stamps.
   - ``ev`` event rate in millions/sec
   - ``%ON`` ratio of ON events to total (ON + OFF) events
   - ``tr`` rate of trigger messages

--- a/src/perf_ros2.cpp
+++ b/src/perf_ros2.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <rclcpp/rclcpp.hpp>
 #include <unordered_map>
+#include <vector>
 
 void usage()
 {
@@ -51,12 +52,21 @@ public:
   // ---------- from the EventProcessor interface:
   void eventCD(uint64_t sensor_time, uint16_t, uint16_t, uint8_t p) override
   {
-    lastSensorTime_ = sensor_time;
     cdEvents_[std::min(uint8_t(1), p)]++;
+    if (isFirstEvent_) {
+      sensorTimes_.push_back(static_cast<int64_t>(sensor_time));
+      hostTimes_.push_back(static_cast<int64_t>(headerStamp_.nanoseconds()));
+      isFirstEvent_ = false;
+      if (isVeryFirstEvent_) {
+        firstSensorTime_ = static_cast<int64_t>(sensor_time);
+        firstHeaderStamp_ = static_cast<int64_t>(headerStamp_.nanoseconds());
+        isVeryFirstEvent_ = false;
+      }
+    }
   }
   bool eventExtTrigger(uint64_t sensor_time, uint8_t edge, uint8_t /*id*/) override
   {
-    lastSensorTime_ = sensor_time;
+    (void)sensor_time;
     trEvents_[std::min(uint8_t(1), edge)]++;
     return (true);
   }
@@ -65,11 +75,13 @@ public:
   // -------- end of inherited
   void eventMsg(EventPacket::ConstSharedPtr msg)
   {
+    headerStamp_ = rclcpp::Time(msg->header.stamp);
     auto decoder = decoderFactory_.getInstance(msg->encoding, msg->width, msg->height);
     if (!decoder) {
       printf("unsupported encoding: %s\n", msg->encoding.c_str());
       return;
     }
+    isFirstEvent_ = true;
     decoder->setTimeBase(msg->time_base);
     decoder->decode(&msg->events[0], msg->events.size(), this);
     numMsgs_++;
@@ -79,15 +91,30 @@ public:
     numSeqDropped_ += (msg->seq - 1 - lastSeq_);
     lastSeq_ = msg->seq;
     const auto t = this->get_clock()->now();
-    const auto t_stamp = rclcpp::Time(msg->header.stamp);
-    delay_ += (t - t_stamp).nanoseconds();
-    if (previousSensorTime_ != 0) {
-      const int64_t dd = (int64_t(lastSensorTime_) - int64_t(previousSensorTime_)) -
-                         (int64_t(t_stamp.nanoseconds()) - int64_t(previousStamp_));
-      drift_ += dd;
+    delay_ += (t - headerStamp_).nanoseconds();
+  }
+
+  std::tuple<double, double> computeTimeStatistics()
+  {
+    if (sensorTimes_.size() != hostTimes_.size() || sensorTimes_.size() < 2) {
+      return (std::make_tuple(-1.0, -1.0));
     }
-    previousSensorTime_ = lastSensorTime_;
-    previousStamp_ = t_stamp.nanoseconds();
+    int64_t baseOffset = hostTimes_[0] - sensorTimes_[0];
+    double sumOffsets = 0.0;
+    double sumOffsetsSq = 0.0;
+    for (size_t i = 0; i < sensorTimes_.size(); ++i) {
+      const double dt = static_cast<double>(hostTimes_[i] - baseOffset - sensorTimes_[i]);
+      sumOffsets += dt;
+      sumOffsetsSq += dt * dt;
+    }
+    const double N_inv = 1.0 / static_cast<double>(sensorTimes_.size());
+    const double N_inv_m1 = 1.0 / static_cast<double>(sensorTimes_.size() - 1);
+    const double jitter = std::sqrt(sumOffsetsSq * N_inv_m1 - N_inv * N_inv_m1 * sumOffsets) * 1e-9;
+    const double drift =
+      ((hostTimes_.back() - firstHeaderStamp_) - (sensorTimes_.back() - firstSensorTime_)) * 1e-9;
+    sensorTimes_.clear();
+    hostTimes_.clear();
+    return (std::make_tuple(drift, jitter));
   }
 
   void timerExpired()
@@ -101,21 +128,21 @@ public:
     const double t_elapsed = (t - firstTime_).nanoseconds() * 1e-9;
     const double dt = (t - lastTime_).nanoseconds() * 1e-9;  // in milliseconds
     if (numMsgs_ != 0 && t_elapsed > 1e-3) {
+      const auto [drift, jitter] = computeTimeStatistics();
       printf(
-        "%.0f msgs: %8.2f/s drp: %" PRIu64 " del: %5.2fms drft: %8.4fs", t_elapsed, numMsgs_ / dt,
-        numSeqDropped_, delay_ / (1e6 * numMsgs_), drift_ * 1e-9);
+        "%.0f msgs: %8.2f/s drp: %" PRIu64 " del: %5.2fms drft: %7.4fms jit: %7.4fms", t_elapsed,
+        numMsgs_ / dt, numSeqDropped_, delay_ / (1e6 * numMsgs_), drift * 1e3, jitter * 1e3);
       const size_t cdTot = cdEvents_[0] + cdEvents_[1];
       if (cdTot > 0) {
         printf(" ev: %8.4f M/s %%ON: %3zu", cdTot / dt * 1e-6, (cdEvents_[1] * 100) / cdTot);
       }
       const size_t trTot = trEvents_[0] + trEvents_[1];
       if (trTot > 0) {
-        printf(" tr: %8.2f 1/s %%UP: %3zu\n", trTot / dt, (trEvents_[1] * 100) / trTot);
-      } else {
-        printf("\n");
+        printf(" tr: %8.2f 1/s %%UP: %3zu", trTot / dt, (trEvents_[1] * 100) / trTot);
       }
+      printf("\n");
     } else {
-      printf("no messages received ...\n");
+      printf("no messages received yet...\n");
     }
     cdEvents_[0] = cdEvents_[1] = 0;
     trEvents_[0] = trEvents_[1] = 0;
@@ -134,14 +161,17 @@ public:
 
   rclcpp::Time firstTime_;
   rclcpp::Time lastTime_;
+  rclcpp::Time headerStamp_;
+  int64_t firstHeaderStamp_;
+  int64_t firstSensorTime_{0};
+  std::vector<int64_t> sensorTimes_;
+  std::vector<int64_t> hostTimes_;
   uint64_t lastSeq_{0};
   uint64_t numSeqDropped_{0};
-  uint64_t lastSensorTime_{0};
-  uint64_t previousSensorTime_{0};
-  uint64_t previousStamp_{0};
   int64_t delay_{0};
-  int64_t drift_{0};
   bool hasValidTime_{false};
+  bool isFirstEvent_{true};
+  bool isVeryFirstEvent_{true};
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Provide a way of measuring the jitter between ROS and sensor time stamps. Turns out to be typically about 300us running the driver on an otherwise idle laptop.
Related to [this issue about time stamps](https://github.com/ros-event-camera/event_camera_codecs/issues/27)