### PR TITLE
Remove unused include of rosbag2_cpp/typesupport_helpers.hpp

### DIFF
--- a/include/event_camera_tools/ros_compat.h
+++ b/include/event_camera_tools/ros_compat.h
@@ -26,7 +26,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/serialized_message.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/writer.hpp>
 #include <rosbag2_cpp/writers/sequential_writer.hpp>
 #include <rosbag2_storage/serialized_bag_message.hpp>

--- a/src/find_trigger_events_ros2.cpp
+++ b/src/find_trigger_events_ros2.cpp
@@ -23,7 +23,6 @@
 #include <rclcpp/serialized_message.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/readers/sequential_reader.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/writer.hpp>
 #include <rosbag2_cpp/writers/sequential_writer.hpp>
 #include <rosbag2_storage/serialized_bag_message.hpp>


### PR DESCRIPTION
This header file was [removed](https://github.com/ros2/rosbag2/pull/2017) in Jazzy (rosbag2 release 0.26.10). Since nothing seems to use this header file, let's remove it.

This fixes the following compile error:

    In file included from src/raw_to_bag.cpp:20:
    include/event_camera_tools/ros_compat.h:29:10: fatal error:
    rosbag2_cpp/typesupport_helpers.hpp: No such file or directory
       29 | #include <rosbag2_cpp/typesupport_helpers.hpp>
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~