### PR TITLE
rely on event_camera_codecs and _msgs packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,3 @@ jobs:
     uses: ros-misc-utilities/ros_build_scripts/.github/workflows/ci_humble_and_later.yml@master
     with:
       repo: ${{ github.event.repository.name }}
-      vcs_url: ${{ github.event.repository.name }}.repos

--- a/event_camera_tools.repos
+++ b/event_camera_tools.repos
@@ -1,9 +1,0 @@
-repositories:
-  event_camera_msgs:
-    type: git
-    url: https://github.com/ros-event-camera/event_camera_msgs.git
-    version: master
-  event_camera_codecs:
-    type: git
-    url: https://github.com/ros-event-camera/event_camera_codecs.git
-    version: master

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,8 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_ros</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake_auto</buildtool_depend>
+  <depend condition="$ROS_VERSION == 2">event_camera_msgs</depend>
+  <depend condition="$ROS_VERSION == 2">event_camera_codecs</depend>
   <depend condition="$ROS_VERSION == 2">libopencv-dev</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>


### PR DESCRIPTION
Now that event_camera_codecs and event_camera_msgs are in all rosdistros, avoid the overhead of building them during testing.