### PR TITLE
store in mcap mode (also on humble)

### DIFF
--- a/src/raw_to_bag.cpp
+++ b/src/raw_to_bag.cpp
@@ -50,7 +50,10 @@ public:
 #ifdef USING_ROS_1
     writer_->open(bagName, rosbag::bagmode::Write);
 #else
-    writer_->open(bagName);
+    rosbag2_storage::StorageOptions storage_options;
+    storage_options.uri = bagName;
+    storage_options.storage_id = "mcap";
+    writer_->open(storage_options);
 #endif
     createTopic(topic);
     msg_.header.frame_id = frameId;


### PR DESCRIPTION
Write in mcap mode because it is the more modern format.
Mcap is the default on the newer ROS2 versions, but not on Humble.